### PR TITLE
feat: distroless dockerfile and goreleaser ghcr publish pipeline

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,21 +3,27 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.21']
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Display Go version
-        run: go version
-      - name: Build
-        run: go build -o md-http .
-      - name: Test with the Go CLI
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Test
         timeout-minutes: 1
         run: go test -v .
-      - name: Ensure go binary runs
-        run: ./md-http -help
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --snapshot --clean --skip=publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: stable
+          go-version-file: go.mod
 
       - uses: docker/setup-qemu-action@v3
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,40 @@
+name: Release
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,10 +1,6 @@
 version: 2
 project_name: md-http
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: md-http
     main: .

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,95 @@
+version: 2
+project_name: md-http
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: md-http
+    main: .
+    binary: md-http
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+
+archives:
+  - formats: [tar.gz]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: 'checksums.txt'
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+
+dockers:
+  - id: md-http-amd64
+    image_templates:
+      - "ghcr.io/astromechza/md-http:{{ .Version }}-amd64"
+      - "ghcr.io/astromechza/md-http:latest-amd64"
+    use: buildx
+    dockerfile: Dockerfile
+    goos: linux
+    goarch: amd64
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=Serve markdown files as HTML over HTTP"
+      - "--label=org.opencontainers.image.source=https://github.com/astromechza/md-http"
+      - "--label=org.opencontainers.image.url=https://github.com/astromechza/md-http"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - id: md-http-arm64
+    image_templates:
+      - "ghcr.io/astromechza/md-http:{{ .Version }}-arm64"
+      - "ghcr.io/astromechza/md-http:latest-arm64"
+    use: buildx
+    dockerfile: Dockerfile
+    goos: linux
+    goarch: arm64
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description=Serve markdown files as HTML over HTTP"
+      - "--label=org.opencontainers.image.source=https://github.com/astromechza/md-http"
+      - "--label=org.opencontainers.image.url=https://github.com/astromechza/md-http"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+docker_manifests:
+  - name_template: "ghcr.io/astromechza/md-http:{{ .Version }}"
+    image_templates:
+      - "ghcr.io/astromechza/md-http:{{ .Version }}-amd64"
+      - "ghcr.io/astromechza/md-http:{{ .Version }}-arm64"
+  - name_template: "ghcr.io/astromechza/md-http:latest"
+    image_templates:
+      - "ghcr.io/astromechza/md-http:latest-amd64"
+      - "ghcr.io/astromechza/md-http:latest-arm64"
+
+release:
+  github:
+    owner: astromechza
+    name: md-http

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM golang:1-alpine AS builder
-# Cshoose the latest version from https://github.com/astromechza/md-http/releases
-RUN go install -v github.com/astromechza/md-http@latest
-
-FROM alpine
-COPY --from=builder /go/bin/md-http /md-http
-RUN echo "hello world" > markdown.md
-ENTRYPOINT ["/md-http", "markdown.md"]
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY md-http /md-http
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/md-http"]

--- a/README.md
+++ b/README.md
@@ -50,18 +50,26 @@ Usage: md-http [options...] <filepath>
 ...
 ```
 
-### Install inside your own Docker image
+### Docker
 
-I don't host a Docker image for this binary. If you want to embed it in an image, use a multistep builder. See [Dockerfile](./Dockerfile):
+Pre-built multi-arch images (linux/amd64, linux/arm64) are published to GHCR on each release:
 
 ```
-FROM golang:1-alpine AS builder
-RUN go install -v github.com/astromechza/md-http@latest
+docker run -v $PWD/your-file.md:/doc.md -p 8080:8080 ghcr.io/astromechza/md-http:latest /doc.md
+```
 
-FROM alpine
-COPY --from=builder /go/bin/md-http /md-http
-RUN echo "hello world" > markdown.md
-ENTRYPOINT ["/md-http", "markdown.md"]
+To extend the image with your own content:
+
+```dockerfile
+FROM ghcr.io/astromechza/md-http:latest
+COPY your-file.md /doc.md
+ENTRYPOINT ["/md-http", "/doc.md"]
+```
+
+To build locally from source using GoReleaser (requires Docker with buildx):
+
+```
+goreleaser release --snapshot --clean --skip=publish
 ```
 
 ### Git clone and build


### PR DESCRIPTION
## Summary
- Replaces alpine self-building Dockerfile with `gcr.io/distroless/static-debian12:nonroot` that consumes the goreleaser-built binary
- Adds `.goreleaser.yaml` for multi-arch linux builds (amd64/arm64) and ghcr.io image publishing with multi-arch manifests
- Adds `.github/workflows/release.yaml` triggered on `v*` tags — logs into ghcr, runs goreleaser

## Usage after merge
```
git tag v0.x.y && git push origin v0.x.y
```
Image lands at `ghcr.io/astromechza/md-http:<version>` and `:latest`.

```
docker run -v $PWD/file.md:/file.md -p 8080:8080 ghcr.io/astromechza/md-http:latest /file.md
```

## Test plan
- [ ] Merge and push a `v*` tag
- [ ] Verify Actions release workflow passes
- [ ] Verify image visible at `https://github.com/astromechza/md-http/pkgs/container/md-http`
- [ ] `docker pull ghcr.io/astromechza/md-http:latest` succeeds on amd64 and arm64

🤖 Generated with [Claude Code](https://claude.ai/claude-code)